### PR TITLE
Center "React Notes" button text

### DIFF
--- a/src/components/MainPanel.tsx
+++ b/src/components/MainPanel.tsx
@@ -118,6 +118,7 @@ const H2 = styled.h2`
 const H3 = styled(H2)`
     font-size: 1.25rem;
     color: var(--fg-text);
+    margin-bottom: 0;
 
     &.hover-on:hover {
         color: var(--fg-text-bold);


### PR DESCRIPTION
H3 styled element had inherited
margin-bottom of "0.5rem". Setting
margin-bottom to "0" for H3.