### PR TITLE
Temporarily remove hosted app links during move

### DIFF
--- a/src/components/MainPanel.tsx
+++ b/src/components/MainPanel.tsx
@@ -232,7 +232,7 @@ function MainPanel(props: {}) {
                         <a href="https://github.com/olsonadr"><GithubGlyph /></a>
                         <a href="https://www.linkedin.com/in/olson-nick/"><LinkedinGlyph /></a>
                     </SocialGlyphRow>
-                    <H2>or enjoy a hosted app</H2>
+                    {/* <H2>or enjoy a hosted app</H2>
                     <LinkList>
                         <LinkListItem href="https://notes.nicholasolson.dev" leftIcon={<FaFeather />} rightIcon={<ChevronIcon />}>
                             <LinkListItemText className="hover-on">React Notes</LinkListItemText>
@@ -240,7 +240,7 @@ function MainPanel(props: {}) {
                         <LinkListItem href="https://blackboard.nicholasolson.dev" leftIcon={<FaBrain />} rightIcon={<ChevronIcon />}>
                             <LinkListItemText className="hover-on">Blackboard AI</LinkListItemText>
                         </LinkListItem>
-                    </LinkList>
+                    </LinkList> */}
                 </MainColumn>
             </Main>
         </>


### PR DESCRIPTION
Until I have finished my move, my hosted apps
will be unavailable, as they require a backend
which will not be hosted. This commit will be
reverted once the server is back online.